### PR TITLE
Use extension when requiring a json file

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,5 @@
 var generatePrime = require('./lib/generatePrime')
-var primes = require('./lib/primes')
+var primes = require('./lib/primes.json')
 
 var DH = require('./lib/dh')
 


### PR DESCRIPTION
The lack of the `.json` makes webpack unhappy.
See https://github.com/webpack/node-libs-browser/issues/19